### PR TITLE
Real time option in clock. Logging level changed. Delay fields removed

### DIFF
--- a/src/main/java/pl/edu/pk/iti/copperAnt/simulation/Clock.java
+++ b/src/main/java/pl/edu/pk/iti/copperAnt/simulation/Clock.java
@@ -14,11 +14,15 @@ public class Clock {
 	private FinishCondition finishCondition = new EmptyListFinishCondition();
 
 	long currentTime;
+	long lastEventTime;
+	boolean realTime = false;
 
 	List<Event> events;
+	private long timeScale = 10;
 
 	public Clock() {
 		this.currentTime = -1;
+		this.lastEventTime = -1;
 		events = new ArrayList<Event>();
 	}
 
@@ -46,7 +50,14 @@ public class Clock {
 
 	public void tick() {
 		if (!finishCondition.isSatisfied(this)) {
+			this.lastEventTime = this.currentTime;
 			this.currentTime = events.get(0).getTime();
+			if (realTime) {
+				try {
+					Thread.sleep((currentTime - lastEventTime) * timeScale);
+				} catch (InterruptedException e) {
+				}
+			}
 			while (!events.isEmpty() && events.get(0).getTime() == currentTime) {
 				Event eventToRun = events.get(0);
 				events.remove(eventToRun);
@@ -81,5 +92,21 @@ public class Clock {
 
 	public long getCurrentTime() {
 		return currentTime;
+	}
+
+	public long getTimeScale() {
+		return timeScale;
+	}
+
+	public void setTimeScale(long timeScale) {
+		this.timeScale = timeScale;
+	}
+
+	public boolean isRealTime() {
+		return realTime;
+	}
+
+	public void setRealTime(boolean realTime) {
+		this.realTime = realTime;
 	}
 }

--- a/src/main/java/pl/edu/pk/iti/copperAnt/simulation/events/CableReceivesEvent.java
+++ b/src/main/java/pl/edu/pk/iti/copperAnt/simulation/events/CableReceivesEvent.java
@@ -37,7 +37,7 @@ public class CableReceivesEvent extends Event {
 			cable.setState(CableState.COLISION);
 			log.debug("There was collision. Package was lost.");
 		}
-		log.debug(this.toString());
+		log.info(this.toString());
 	}
 
 	@Override

--- a/src/main/java/pl/edu/pk/iti/copperAnt/simulation/events/CableSendsEvent.java
+++ b/src/main/java/pl/edu/pk/iti/copperAnt/simulation/events/CableSendsEvent.java
@@ -10,7 +10,6 @@ import pl.edu.pk.iti.copperAnt.network.Port;
 import pl.edu.pk.iti.copperAnt.simulation.Clock;
 
 public class CableSendsEvent extends Event {
-	private static final long DELAY = 1;
 	private static final Logger log = LoggerFactory
 			.getLogger(CableSendsEvent.class);
 	private Port port;
@@ -28,12 +27,12 @@ public class CableSendsEvent extends Event {
 	@Override
 	public void run(Clock clock) {
 		if (!cable.getState().equals(CableState.COLISION)) {
-			clock.addEvent(new PortReceivesEvent(time + DELAY, port, pack));
+			clock.addEvent(new PortReceivesEvent(time, port, pack));
 		}
 		if (cable.getBusyUntilTime() <= time) {
 			cable.setState(CableState.IDLE);
 		}
-		log.debug(toString());
+		log.info(toString());
 
 	}
 

--- a/src/main/java/pl/edu/pk/iti/copperAnt/simulation/events/CoputerSendsEvent.java
+++ b/src/main/java/pl/edu/pk/iti/copperAnt/simulation/events/CoputerSendsEvent.java
@@ -1,5 +1,8 @@
 package pl.edu.pk.iti.copperAnt.simulation.events;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import pl.edu.pk.iti.copperAnt.network.Computer;
 import pl.edu.pk.iti.copperAnt.network.Package;
 import pl.edu.pk.iti.copperAnt.simulation.Clock;
@@ -7,7 +10,8 @@ import pl.edu.pk.iti.copperAnt.simulation.ConstantTimeIntervalGenerator;
 import pl.edu.pk.iti.copperAnt.simulation.TimeIntervalGenerator;
 
 public class CoputerSendsEvent extends Event {
-	private static final long DELAY = 1;
+	private static final Logger log = LoggerFactory
+			.getLogger(CoputerSendsEvent.class);
 	private Computer computer;
 	private Package pack;
 	// TODO tu bedzie zastosowana inna implementacja
@@ -23,15 +27,15 @@ public class CoputerSendsEvent extends Event {
 	@Override
 	public void run(Clock clock) {
 		long timeToNextEvent = intervalGenerator.getTimeInterval();
-		PortSendsEvent event = new PortSendsEvent(time + DELAY,
-				computer.getPort(), pack);
+		PortSendsEvent event = new PortSendsEvent(time, computer.getPort(),
+				pack);
 
 		CoputerSendsEvent nextComputerSendsEvent = new CoputerSendsEvent(time
 				+ timeToNextEvent, computer, pack)
 				.withIntervalGenerator(this.intervalGenerator);
 		clock.addEvent(event);
 		clock.addEvent(nextComputerSendsEvent);
-
+		log.info(this.toString());
 	}
 
 	public TimeIntervalGenerator getIntervalGenerator() {

--- a/src/main/java/pl/edu/pk/iti/copperAnt/simulation/events/PortReceivesEvent.java
+++ b/src/main/java/pl/edu/pk/iti/copperAnt/simulation/events/PortReceivesEvent.java
@@ -11,7 +11,6 @@ public class PortReceivesEvent extends Event {
 	private static final Logger log = LoggerFactory
 			.getLogger(PortReceivesEvent.class);
 
-	private static final long timeOfProcessing = 1;
 	private Port port;
 	private Package pack;
 
@@ -25,7 +24,7 @@ public class PortReceivesEvent extends Event {
 	@Override
 	public void run(Clock clock) {
 		port.getDevice().acceptPackage(pack);
-		log.debug(this.toString());
+		log.info(this.toString());
 
 	}
 

--- a/src/main/java/pl/edu/pk/iti/copperAnt/simulation/events/PortSendsEvent.java
+++ b/src/main/java/pl/edu/pk/iti/copperAnt/simulation/events/PortSendsEvent.java
@@ -11,8 +11,6 @@ public class PortSendsEvent extends Event {
 	private static final Logger log = LoggerFactory
 			.getLogger(PortSendsEvent.class);
 
-	private static final long timeOfProcessing = 1;
-
 	private Port port;
 
 	private Package pack;
@@ -26,10 +24,8 @@ public class PortSendsEvent extends Event {
 
 	@Override
 	public void run(Clock clock) {
-		log.debug(this.toString());
-
-		clock.addEvent(new CableReceivesEvent(this.time + timeOfProcessing,
-				port, pack));
+		clock.addEvent(new CableReceivesEvent(this.time, port, pack));
+		log.info(this.toString());
 
 	}
 

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -11,7 +11,7 @@
     </appender>
 
     <logger name="pl.edu.pk.iti.copperAnt">
-        <level value="DEBUG"/>
+        <level value="INFO"/>
     </logger>
 
     <root>

--- a/src/test/java/pl/edu/pk/iti/copperAnt/simulation/RealTimeSimulationSandbox.java
+++ b/src/test/java/pl/edu/pk/iti/copperAnt/simulation/RealTimeSimulationSandbox.java
@@ -1,0 +1,54 @@
+package pl.edu.pk.iti.copperAnt.simulation;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import pl.edu.pk.iti.copperAnt.network.Cable;
+import pl.edu.pk.iti.copperAnt.network.Computer;
+import pl.edu.pk.iti.copperAnt.network.Hub;
+
+public class RealTimeSimulationSandbox {
+
+	@Test
+	@Ignore
+	public void sandbox2() {
+		Clock clock = new Clock()
+				.withFinishCondition(new MaxTimeFinishCondition(100));
+		clock.setRealTime(true);
+		clock.setTimeScale(500);
+		Computer computer1 = new Computer();
+		Computer computer2 = new Computer();
+		Cable cable = new Cable();
+		cable.insertInto(computer1.getPort());
+		cable.insertInto(computer2.getPort());
+
+		computer1.initTrafic(clock);
+		clock.run();
+	}
+
+	@Test
+	@Ignore
+	public void sandbox3() {
+		Clock clock = new Clock()
+				.withFinishCondition(new MaxTimeFinishCondition(100));
+		clock.setRealTime(true);
+		clock.setTimeScale(500);
+		Hub hub = new Hub(3, clock);
+		Computer computer1 = new Computer();
+		Computer computer2 = new Computer();
+		Computer computer3 = new Computer();
+		connectComputerToHub(computer1, hub, 0);
+		connectComputerToHub(computer2, hub, 1);
+		connectComputerToHub(computer3, hub, 2);
+
+		computer1.initTrafic(clock);
+		clock.run();
+	}
+
+	private void connectComputerToHub(Computer computer, Hub hub, int portNr) {
+		Cable cable = new Cable();
+		cable.insertInto(computer.getPort());
+		cable.insertInto(hub.getPort(portNr));
+	}
+
+}


### PR DESCRIPTION
Mała modyfikacja w zegarze. Można aktywować tryb w którym zegar będzie przysypiał na pewien czas między zdarzeniami. Dzięki temu z zewnątrz symulacja zaczyna wyglądać jakby się działa w normalnym czasie (a nie w czasie zdarzeń dyskretnych). Dzięki temu będzie można przedstawiać ją na animacjach jeśli będzie taka chęć. 
